### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *	text	working-tree-encoding=ISO8859-1
+*.gz    zos-working-tree-encoding=BINARY


### PR DESCRIPTION
I hit below git clone problem, so insert a new statement **_"*.gz    zos-working-tree-encoding=BINARY"_** in the file ".gitattributes".

_**git clone git@github.com:ZOSOpenTools/zotsampleport.git
Cloning into 'zotsampleport'...
warning: templates not found /rsusr/ported/share/git-core/templates
remote: Enumerating objects: 116, done.
remote: Counting objects: 100% (116/116), done.
remote: Compressing objects: 100% (86/86), done.
remote: Total 116 (delta 44), reused 92 (delta 26), pack-reused 0
Receiving objects: 100% (116/116), 27.93 KiB | 1.75 MiB/s, done.
Resolving deltas: 100% (44/44), done.
fatal: tarballs/zotsample-1.0.tar.gz: conversion from ISO8859-1 to BINARY not supported
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'_**_

Sunny