### PR TITLE
Add texinfo to resolve check error, plus also add gettext to get over warning

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -5,7 +5,7 @@ export ZOPEN_TYPE="TARBALL"
 
 ZOPEN_TARBALL_DIR=m4-1.4.19
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/gnu/m4/${ZOPEN_TARBALL_DIR}.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl gzip make m4"
+export ZOPEN_TARBALL_DEPS="curl gzip make m4 gettext texinfo"
 
 ZOPEN_GIT_DIR=m4
 export ZOPEN_GIT_URL="git://git.savannah.gnu.org/${ZOPEN_GIT_DIR}.git"


### PR DESCRIPTION
Resolves:
```
makeinfo: /jenkins/PortBuild/m4/m4-1.4.19/build-aux/missing 81: FSUM7351 not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         https://www.gnu.org/software/texinfo/
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         https://www.gnu.org/software/make/
```